### PR TITLE
Optional disable power-of-two argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # PNG Power-of-2 Cropper
 
-A Python script that processes PNG images with transparency, automatically cropping them to the smallest power-of-2 dimensions that can contain the non-transparent content. This is particularly useful for optimizing sprite sheets, textures, and other game assets where power-of-2 dimensions are required.
+A Python script that processes PNG images with transparency, automatically cropping them to the smallest power-of-2 (optional) dimensions that can contain the non-transparent content. This is particularly useful for optimizing sprite sheets, textures, and other game assets where power-of-2 dimensions are required.
 
 ## Features
 
 - Automatically detects non-transparent pixels in PNG images
 - Crops images to the smallest possible power-of-2 dimensions
+- Power of 2 constraint can be disabled for maximum crop
 - Centers the content in the output image
 - Optional uniform size mode where all images use the same dimensions
 - Preserves transparency
@@ -34,6 +35,11 @@ Uniform size mode (all images cropped to the same size):
 python cropper.py --uniform
 ```
 
+Uniform size mode with power-of-two constraint disabled (closest possible crop):
+```bash
+python cropper.py --uniform --nonpow2
+```
+
 The script will:
 - Create a 'cropped' subfolder in the same directory
 - Process all PNG files in the directory
@@ -43,6 +49,7 @@ The script will:
 ## Command Line Arguments
 
 - `--uniform`: Make all output images the same size based on the largest content found in any image
+- `--uniform --nonpow2`: Disable power-of-two constraint for closest possible crop
 
 ## Example
 
@@ -57,4 +64,9 @@ Uniform mode:
 - Input2: sprite2.png (512x256 with content only using 434x115 pixels)
 - All outputs: 512x128 (based on largest content dimensions)
 
+Uniform Non-Pow2 mode:
+- Input1: sprite1.png (434x115 with content only using 196x111 pixels)
+- Input2: sprite2.png (434x115 with content only using 434x115 pixels)
+- All outputs: 434x115 (based on largest content dimensions)
+- 
 [Rest of README remains the same...]

--- a/cropper.py
+++ b/cropper.py
@@ -1,7 +1,7 @@
 """
 PNG Power-of-2 Cropper
 A script that processes PNG images with transparency, automatically cropping them 
-to the smallest power-of-2 dimensions that can contain the non-transparent content.
+to the smallest power-of-2 (optional) dimensions that can contain the non-transparent content.
 
 Copyright (C) 2024 Frederik Sjölund
 
@@ -128,9 +128,11 @@ def process_image(input_path, output_dir, target_width=None, target_height=None)
 
 def main():
     # Set up command line arguments
-    parser = argparse.ArgumentParser(description='Crop PNG images to power-of-2 dimensions.')
+    parser = argparse.ArgumentParser(description='Crop PNG images to (optional) power-of-2 dimensions.')
     parser.add_argument('--uniform', action='store_true',
                        help='Make all output images the same size based on the largest content')
+    parser.add_argument('--nonpow2', action='store_true',
+                   help='Disable power of two constraint')
     args = parser.parse_args()
     
     # Get the directory containing the script
@@ -149,9 +151,15 @@ def main():
     
     if args.uniform and png_files:
         max_width, max_height = get_max_content_dimensions(png_files)
-        target_width = get_next_power_of_2(max_width)
-        target_height = get_next_power_of_2(max_height)
-        print(f"Using uniform size for all images: {target_width}x{target_height}")
+        if args.nonpow2:
+            target_width = max_width
+            target_height = max_height
+        else:
+            target_width = get_next_power_of_2(max_width)
+            target_height = get_next_power_of_2(max_height)
+            
+        pow2text = "non-power-of-two" if args.nonpow2 else "(power-of-two)"        
+        print(f"Using uniform size {pow2text} for all images: {target_width}x{target_height}")
     
     # Process all PNG files
     for file_path in png_files:


### PR DESCRIPTION
Added --nonpow2 argument to disable power-of-two constraint ( gives maximum possible crop to bounds of largest image when used alongside --uniform argument )